### PR TITLE
Add basic command list to help

### DIFF
--- a/src/main/kotlin/dev/arbjerg/ukulele/command/HelpCommand.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/command/HelpCommand.kt
@@ -1,15 +1,35 @@
 package dev.arbjerg.ukulele.command
 
+import dev.arbjerg.ukulele.config.BotProps
 import dev.arbjerg.ukulele.features.HelpContext
 import dev.arbjerg.ukulele.jda.Command
 import dev.arbjerg.ukulele.jda.CommandContext
+import net.dv8tion.jda.api.MessageBuilder
 import org.springframework.stereotype.Component
 
 @Component
 class HelpCommand : Command("help") {
-    override suspend fun CommandContext.invoke() {
-        val command = beans.commandManager[argumentText.trim()] ?: return replyHelp()
-        replyHelp(command)
+    override suspend fun CommandContext.invoke() = when {
+        argumentText.isNotBlank() -> {
+            val command = beans.commandManager[argumentText.trim()]
+            if (command == null) {
+                replyHelp()
+            } else {
+                replyHelp(command)
+            }
+        }
+        else -> {
+            val commands = beans.commandManager.getCommands()
+            val msg = MessageBuilder()
+                .append("Available commands:")
+                .appendCodeBlock(buildString {
+                    commands.forEach {
+                        appendLine((listOf(it.name) + it.aliases).joinToString())
+                    }
+                }, "")
+                .append("Use `${trigger} <command>` to see more details.")
+            replyMsg(msg.build())
+        }
     }
 
     override fun HelpContext.provideHelp() {

--- a/src/main/kotlin/dev/arbjerg/ukulele/jda/CommandContext.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/jda/CommandContext.kt
@@ -44,6 +44,10 @@ class CommandContext(
         channel.sendMessage(msg).queue()
     }
 
+    fun replyMsg(msg: Message) {
+        channel.sendMessage(msg).queue()
+    }
+
     fun replyEmbed(embed: MessageEmbed) {
         channel.sendMessage(embed).queue()
     }

--- a/src/main/kotlin/dev/arbjerg/ukulele/jda/CommandManager.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/jda/CommandManager.kt
@@ -37,6 +37,8 @@ class CommandManager(
 
     operator fun get(commandName: String) = registry[commandName]
 
+    fun getCommands() = registry.values.distinct()
+
     fun onMessage(guild: Guild, channel: TextChannel, member: Member, message: Message) {
         GlobalScope.launch {
             // TODO: Allow mentions


### PR DESCRIPTION
This PR adds a basic list of available commands when `::help` is used with no argument.
![image](https://user-images.githubusercontent.com/1972633/133862257-dd458b1e-3d9a-462e-b493-42314705fc3f.png)
