### PR TITLE
Automatically leave voice channel after some time spent idle

### DIFF
--- a/src/main/kotlin/dev/arbjerg/ukulele/UkuleleApplication.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/UkuleleApplication.kt
@@ -3,9 +3,11 @@ package dev.arbjerg.ukulele
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 class UkuleleApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/dev/arbjerg/ukulele/config/BotProps.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/config/BotProps.kt
@@ -9,5 +9,6 @@ class BotProps(
         var prefix: String = "::",
         var database: String = "./database",
         var game: String = "",
-        var trackDurationLimit: Int = 0
+        var trackDurationLimit: Int = 0,
+        var idleTimeMinutes: Int = 10
 )

--- a/src/main/kotlin/dev/arbjerg/ukulele/features/LeaveOnIdle.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/features/LeaveOnIdle.kt
@@ -1,0 +1,78 @@
+package dev.arbjerg.ukulele.features
+
+import dev.arbjerg.ukulele.audio.Player
+import org.springframework.stereotype.Service
+import dev.arbjerg.ukulele.audio.PlayerRegistry
+import dev.arbjerg.ukulele.config.BotProps
+import dev.arbjerg.ukulele.data.GuildPropertiesService
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.VoiceChannel
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.TaskScheduler
+import java.time.Duration
+import java.util.concurrent.ScheduledFuture
+
+@Service
+class LeaveOnIdle(
+        private val players: PlayerRegistry,
+        private val guildPropertiesService: GuildPropertiesService,
+        private val scheduler: TaskScheduler,
+        private val botProps: BotProps
+) {
+    private val log: Logger = LoggerFactory.getLogger(LeaveOnIdle::class.java)
+    private val timers: MutableMap<Guild, ScheduledFuture<*>> = HashMap()
+
+    fun onVoiceJoin(guild: Guild, channel: VoiceChannel, member: Member) {
+        if (member == guild.selfMember) {
+            log.info("Joined voice channel {} in guild {}", channel.name, guild.name)
+            createTimer(guild)
+        }
+    }
+
+    fun onVoiceLeave(guild: Guild, channel: VoiceChannel, member: Member) {
+        if (member == guild.selfMember) {
+            log.info("Left voice channel {} in guild {}", channel.name, guild.name)
+            removeTimer(guild)
+        }
+    }
+
+    private fun createTimer(guild: Guild) {
+        GlobalScope.launch {
+            val taskPeriod = Duration.ofMinutes(1)
+            val player = players.get(guild, guildPropertiesService.getAwait(guild.idLong))
+            val timerTaskFuture = scheduler.scheduleAtFixedRate(IdleTask(guild, player, botProps.idleTimeMinutes), taskPeriod)
+
+            timers[guild] = timerTaskFuture
+        }
+    }
+
+    private fun removeTimer(guild: Guild) {
+        timers[guild]?.let {
+            it.cancel(true)
+            timers.remove(guild)
+        }
+    }
+}
+
+class IdleTask(val guild: Guild, val player: Player, val idleTimeMinutes: Int) : Runnable {
+    private var numberOfMinutesIdleElapsed = 0
+    private val log: Logger = LoggerFactory.getLogger(IdleTask::class.java)
+
+    override fun run() {
+        if (player.remainingDuration <= 0) {
+            // the player is idle, increment our minutes elapsed
+            numberOfMinutesIdleElapsed++
+        } else {
+            // if the player has something in its queue, reset to 0
+            numberOfMinutesIdleElapsed = 0
+        }
+
+        if (numberOfMinutesIdleElapsed >= idleTimeMinutes) {
+            guild.audioManager.closeAudioConnection()
+        }
+    }
+}

--- a/src/main/kotlin/dev/arbjerg/ukulele/jda/EventHandler.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/jda/EventHandler.kt
@@ -1,7 +1,9 @@
 package dev.arbjerg.ukulele.jda
 
-import net.dv8tion.jda.api.events.ReadyEvent
+import dev.arbjerg.ukulele.features.LeaveOnIdle
 import net.dv8tion.jda.api.events.StatusChangeEvent
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceJoinEvent
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceLeaveEvent
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import org.slf4j.Logger
@@ -9,7 +11,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
-class EventHandler(private val commandManager: CommandManager) : ListenerAdapter() {
+class EventHandler(private val commandManager: CommandManager, private val leaveOnIdle: LeaveOnIdle) : ListenerAdapter() {
 
     private val log: Logger = LoggerFactory.getLogger(EventHandler::class.java)
 
@@ -22,4 +24,11 @@ class EventHandler(private val commandManager: CommandManager) : ListenerAdapter
         log.info("{}: {} -> {}", event.entity.shardInfo, event.oldStatus, event.newStatus)
     }
 
+    override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent) {
+        leaveOnIdle.onVoiceJoin(event.guild, event.channelJoined, event.member)
+    }
+
+    override fun onGuildVoiceLeave(event: GuildVoiceLeaveEvent) {
+        leaveOnIdle.onVoiceLeave(event.guild, event.channelLeft, event.member)
+    }
 }


### PR DESCRIPTION
This PR enables the bot to leave a voice channel after some time spent idle. Upon joining a channel, a scheduled task will fire every minute that checks to see if the player is idle. If it is, the task will increment an internal timer. After some configurable amount of time (`idleTimeMinutes` in `ukulele.yml`, defaults to 10 minutes) the task will have the bot automatically leave the voice channel.

First time working with Kotlin and Spring, so please do point out any idiomatic foibles. If there's a linter I should run, I can do that no problem. 

Fixes #26 