### PR TITLE
Handle playlist links with specific song selected

### DIFF
--- a/src/main/kotlin/dev/arbjerg/ukulele/command/PlayCommand.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/command/PlayCommand.kt
@@ -69,6 +69,11 @@ class PlayCommand(
         }
 
         override fun playlistLoaded(playlist: AudioPlaylist) {
+            if (playlist.selectedTrack != null) {
+                this.trackLoaded(playlist.selectedTrack);
+                return
+            }
+
             val accepted = playlist.tracks.filter { !it.isOverDurationLimit }
             val filteredCount = playlist.tracks.size - accepted.size
             if (accepted.isEmpty()) {


### PR DESCRIPTION
If a link contains both a video and a playlist, it will now only add the specific video, not the whole playlist.