### PR TITLE
When searching using '*search:*', only add the first result

### DIFF
--- a/src/main/kotlin/dev/arbjerg/ukulele/command/PlayCommand.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/command/PlayCommand.kt
@@ -76,6 +76,11 @@ class PlayCommand(
                 return
             }
 
+            if (identifier.startsWith("ytsearch") || identifier.startsWith("ytmsearch") || identifier.startsWith("scsearch:")) {
+                this.trackLoaded(accepted.component1());
+                return
+            }
+
             player.add(*accepted.toTypedArray())
             ctx.reply(buildString {
                 append("Added `${accepted.size}` tracks from `${playlist.name}`.")


### PR DESCRIPTION
Currently, only `ytsearch:` `ytmsearch:` and `scsearch:` are handled.