### PR TITLE
Bump version for lavaplayer-fork and add lavaplayer-natives for ARM support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM openjdk:11
 RUN groupadd -r -g 999 ukulele && useradd -rd /opt/ukulele -g ukulele -u 999 -ms /bin/bash ukulele
 COPY --chown=ukulele:ukulele build/libs/ukulele.jar /opt/ukulele/ukulele.jar
-COPY --chown=ukulele:ukulele ukulele.yml /opt/ukulele/ukulele.yml
 USER ukulele
 WORKDIR /opt/ukulele/
 ENTRYPOINT ["java", "-jar", "/opt/ukulele/ukulele.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:11
 RUN groupadd -r -g 999 ukulele && useradd -rd /opt/ukulele -g ukulele -u 999 -ms /bin/bash ukulele
 COPY --chown=ukulele:ukulele build/libs/ukulele.jar /opt/ukulele/ukulele.jar
+COPY --chown=ukulele:ukulele ukulele.yml /opt/ukulele/ukulele.yml
 USER ukulele
 WORKDIR /opt/ukulele/
 ENTRYPOINT ["java", "-jar", "/opt/ukulele/ukulele.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,16 +19,14 @@ repositories {
 }
 
 dependencies {
-    implementation("net.dv8tion:JDA:4.3.0_277")
-    implementation("com.github.walkyst:lavaplayer-fork:1.3.99")
-    implementation("com.github.aikaterna:lavaplayer-natives:f067f4dae7")
+    implementation("net.dv8tion:JDA:4.3.0_279")
+    implementation("com.github.walkyst.lavaplayer-fork:lavaplayer:1.4.0")
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
 
     runtimeOnly("com.h2database:h2")
     implementation("io.r2dbc:r2dbc-h2")
     implementation("org.flywaydb:flyway-core")
-    implementation("com.github.ben-manes.caffeine:caffeine:2.8.6")
-
+    implementation("com.github.ben-manes.caffeine:caffeine:3.1.5")
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,8 +20,8 @@ repositories {
 
 dependencies {
     implementation("net.dv8tion:JDA:4.3.0_277")
-    //implementation("com.sedmelluq:lavaplayer:1.3.78")
-    implementation("com.github.walkyst:lavaplayer-fork:1.3.96")
+    implementation("com.github.walkyst:lavaplayer-fork:1.3.99")
+    implementation("com.github.aikaterna:lavaplayer-natives:f067f4dae7")
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
 
     runtimeOnly("com.h2database:h2")


### PR DESCRIPTION
For context on how I arrived at this solution, there's a discussion about this library over here: https://github.com/sedmelluq/lavaplayer/issues/622 - hopefully resolves the dilemma posed on #50 

This version hash for lavaplayer-natives pins it to the current latest rather than targeting a snapshot version (which could shift over time)

This adds the native dependencies needed to work on alternate CPUs like those found in Raspberry Pi 4 to avoid errors like shown here:

![image](https://user-images.githubusercontent.com/246455/199641014-395c0b4d-bdcc-465a-98d5-4f5cf8089073.png)
