### PR TITLE
Bump the version of JDA to pick up the UDP fix in 4.x

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,11 @@ repositories {
 }
 
 dependencies {
-    implementation("net.dv8tion:JDA:4.3.0_277")
+    // The 4.x version of JDA specifically needs a UDP fix from this commit:
+    // https://github.com/DV8FromTheWorld/JDA/commit/39ba0c2682ad99dbec88240cb8ea9d1ff7162ae9
+    // The snapshot version published in jitpack has this, so it is utilized for now.
+    // Eventually, a full upgrade to JDA 5.x will be necessary.
+    implementation("com.github.DV8FromTheWorld:JDA:legacy~v4-SNAPSHOT")
     //implementation("com.sedmelluq:lavaplayer:1.3.78")
     implementation("com.github.walkyst:lavaplayer-fork:1.3.96")
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")


### PR DESCRIPTION
See https://github.com/DV8FromTheWorld/JDA/pull/2413

There was a breaking change in the Discord API so this bump of JDA is necessary for the bot to function at all.

Closes #65 